### PR TITLE
explicitly reference Rf_error()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: TMBtools
 Type: Package
 Title: Tools for Developing R Packages Interfacing with 'TMB'
-Version: 0.9.1
-Date: 2021-01-08
+Version: 0.9.2
+Date: 2022-02-13
 Authors@R: person("Martin", "Lysy",
                   email = "mlysy@uwaterloo.ca",
 		  role = c("aut", "cre"))

--- a/R/export_models.R
+++ b/R/export_models.R
@@ -56,9 +56,9 @@ export_models <- function(pkg = ".") {
                        '    return ', model_names, '(this);\n',
                        '  }', collapse = ' else ')
     if_lines <- paste0(if_lines, ' else {\n',
-                      '    error("Unknown model.");\n  }')
+                      '    Rf_error("Unknown model.");\n  }')
   } else {
-    if_lines <- '  error("Unknown model.");'
+    if_lines <- '  Rf_error("Unknown model.");'
   }
   use_template(template = "TMBExports.cpp", package = "TMBtools",
                data = list(pkg = pkg_name,

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ devtools::check_win_devel()
 	  } else if(model == "ModelB") {
 		return ModelB(this);
 	  } else {
-		error("Unknown model.");
+		Rf_error("Unknown model.");
 	  }
 	  return 0;
     }

--- a/src/TMB/TMBtools_TMBExports.cpp
+++ b/src/TMB/TMBtools_TMBExports.cpp
@@ -28,7 +28,7 @@ Type objective_function<Type>::operator() () {
   } else if(model == "ySx_pdp") {
     return ySx_pdp(this);
   } else {
-    error("Unknown model.");
+    Rf_error("Unknown model.");
   }
   return 0;
 }

--- a/vignettes/MyTMBPackage_TMBExports.cpp
+++ b/vignettes/MyTMBPackage_TMBExports.cpp
@@ -16,7 +16,7 @@ Type objective_function<Type>::operator() () {
   } else if(model == "ModelC") {
     return ModelC(this);
   } else {
-    error("Unknown model.");
+    Rf_error("Unknown model.");
   }
   return 0;
 }


### PR DESCRIPTION
Hello,

I am making a PR to suggest explicitly calling `Rf_error("Unknown model.")` instead of `error("Unknown model.")` in the `_TMBexports.cpp` file. 

This enables the code to still work when `#define R_NO_REMAP` is declared, which I have had to add to avoid some clashes between `Rinternals.h` and Eigen.

Thanks for your consideration, and for the very useful package.

Thanks,
Jeff
